### PR TITLE
Use daemon_ensure parameter

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -100,6 +100,7 @@ class puppet::agent (
   else                 { $at_boot_ensure = 'absent'  }
 
   service { 'puppet_agent_daemon':
+    ensure => $daemon_ensure,
     name   => $daemon_name,
     enable => $daemon_enable,
   }


### PR DESCRIPTION
The daemon_ensure parameter was unused.  When used with run_methdod = service, the service would be enabled (e.g. at boot time) but puppet would not start the service as it should.